### PR TITLE
Add customId for for animated movements and don't trigger movement when it isn't necessary

### DIFF
--- a/lib/src/animated_map_controller.dart
+++ b/lib/src/animated_map_controller.dart
@@ -67,6 +67,7 @@ class AnimatedMapController extends MapControllerImpl {
     double? zoom,
     double? rotation,
     Curve? curve,
+    String? customId,
   }) {
     if (zoom != null && zoom < 0) {
       throw ArgumentError.value(
@@ -105,6 +106,15 @@ class AnimatedMapController extends MapControllerImpl {
       end: endRotation,
     );
 
+    // Determine the callback for movement. If no movement will occur return
+    // immediately.
+    final bool hasRotation = rotation != null && rotation != this.rotation;
+    final bool hasMovement =
+        (dest != null && dest != center) || (zoom != null && zoom != this.zoom);
+    final movementCallback =
+        _movementCallback(hasMovement: hasMovement, hasRotation: hasRotation);
+    if (movementCallback == null) return Future.value();
+
     // This controller will be disposed when the animation is completed.
     final animationController = AnimationController(
       vsync: vsync,
@@ -123,62 +133,131 @@ class AnimatedMapController extends MapControllerImpl {
     AnimationId animationId = AnimationId(
       destLocation: effectiveDest,
       destZoom: effectiveZoom,
+      customId: customId,
     );
 
     bool hasTriggeredMove = false;
+    bool animationCompleted = false;
 
     animationController.addListener(() {
+      // The animation calls this listener with value 1.0 twice. Once when the
+      // value is 1.0 but isCompleted is false and again when it is still 1.0
+      // and isCompleted is true. This check ensures we don't trigger a
+      // duplicate movement but also, more importantly, that we trigger the
+      // final movement with the finished id exactly once.
+      if (animationCompleted) return;
+      animationCompleted |= animation.value == 1.0;
+
       animationId = animationId.copyWith(
         moveId: AnimatedMoveId.fromAnimationAndTriggeredMove(
-          animationValue: animation.value,
+          animationIsCompleted: animationCompleted,
           hasTriggeredMove: hasTriggeredMove,
         ),
       );
 
-      hasTriggeredMove |= move(
-        latLngTween.evaluate(animation),
-        zoomTween.evaluate(animation),
-        id: animationId.id,
+      hasTriggeredMove |= movementCallback(
+        animation,
+        latLngTween,
+        zoomTween,
+        rotateTween,
+        animationId,
       );
-      rotate(rotateTween.evaluate(animation));
     });
 
     return animationController.forward();
   }
 
+  // Determine what MapController method should be called based on whether
+  // there is movement and/or rotation. If there is neither movement nor
+  // rotation null is returned.
+  bool Function(
+    CurvedAnimation animation,
+    LatLngTween latLngTween,
+    Tween<double> zoomTween,
+    Tween<double> rotateTween,
+    AnimationId animationId,
+  )? _movementCallback({
+    required bool hasMovement,
+    required bool hasRotation,
+  }) {
+    if (hasMovement && hasRotation) {
+      return (animation, latLngTween, zoomTween, rotateTween, animationId) {
+        final result = moveAndRotate(
+          latLngTween.evaluate(animation),
+          zoomTween.evaluate(animation),
+          rotateTween.evaluate(animation),
+          id: animationId.id,
+        );
+        return result.moveSuccess || result.rotateSuccess;
+      };
+    } else if (hasMovement) {
+      return (animation, latLngTween, zoomTween, rotateTween, animationId) =>
+          move(
+            latLngTween.evaluate(animation),
+            zoomTween.evaluate(animation),
+            id: animationId.id,
+          );
+    } else if (hasRotation) {
+      return (animation, latLngTween, zoomTween, rotateTween, animationId) =>
+          rotate(
+            rotateTween.evaluate(animation),
+            id: animationId.id,
+          );
+    } else {
+      return null;
+    }
+  }
+
   /// Center the map on [point] with an optional [zoom] level.
   ///
   /// {@macro animated_map_controller.animate_to.curve}
-  Future<void> centerOnPoint(LatLng point, {double? zoom, Curve? curve}) {
-    return animateTo(dest: point, zoom: zoom, curve: curve);
+  Future<void> centerOnPoint(
+    LatLng point, {
+    double? zoom,
+    Curve? curve,
+    String? customId,
+  }) {
+    return animateTo(dest: point, zoom: zoom, curve: curve, customId: customId);
   }
 
   /// Apply a rotation of [degree] to the current rotation.
   ///
   /// {@macro animated_map_controller.animate_to.curve}
-  Future<void> animatedRotateFrom(double degree, {Curve? curve}) {
-    return animateTo(rotation: rotation + degree, curve: curve);
+  Future<void> animatedRotateFrom(
+    double degree, {
+    Curve? curve,
+    String? customId,
+  }) {
+    return animateTo(
+      rotation: rotation + degree,
+      curve: curve,
+      customId: customId,
+    );
   }
 
   /// Set the rotation to [degree].
   ///
   /// {@macro animated_map_controller.animate_to.curve}
-  Future<void> animatedRotateTo(double degree, {Curve? curve}) {
-    return animateTo(rotation: degree, curve: curve);
+  Future<void> animatedRotateTo(
+    double degree, {
+    Curve? curve,
+    String? customId,
+  }) {
+    return animateTo(rotation: degree, curve: curve, customId: customId);
   }
 
   /// Reset the rotation to 0.
   ///
   /// {@macro animated_map_controller.animate_to.curve}
-  Future<void> animatedRotateReset({Curve? curve}) {
-    return animateTo(rotation: 0, curve: curve);
+  Future<void> animatedRotateReset({Curve? curve, String? customId}) {
+    return animateTo(rotation: 0, curve: curve, customId: customId);
   }
 
   /// Add one level to the current zoom level.
   ///
   /// {@macro animated_map_controller.animate_to.curve}
-  Future<void> animatedZoomIn({Curve? curve}) {
-    return animateTo(zoom: zoom + 1, curve: curve);
+  Future<void> animatedZoomIn({Curve? curve, String? customId}) {
+    return animateTo(zoom: zoom + 1, curve: curve, customId: customId);
   }
 
   /// Remove one level to the current zoom level.
@@ -186,11 +265,11 @@ class AnimatedMapController extends MapControllerImpl {
   /// If the current zoom level is 0, nothing will happen.
   ///
   /// {@macro animated_map_controller.animate_to.curve}
-  FutureOr<void> animatedZoomOut({Curve? curve}) {
+  FutureOr<void> animatedZoomOut({Curve? curve, String? customId}) {
     final newZoom = zoom - 1;
     if (newZoom < 0) return null;
 
-    return animateTo(zoom: newZoom, curve: curve);
+    return animateTo(zoom: newZoom, curve: curve, customId: customId);
   }
 
   /// Set the zoom level to [newZoom].
@@ -198,8 +277,12 @@ class AnimatedMapController extends MapControllerImpl {
   /// [newZoom] must be greater or equal to 0.
   ///
   /// {@macro animated_map_controller.animate_to.curve}
-  Future<void> animatedZoomTo(double newZoom, {Curve? curve}) {
-    return animateTo(zoom: newZoom, curve: curve);
+  Future<void> animatedZoomTo(
+    double newZoom, {
+    Curve? curve,
+    String? customId,
+  }) {
+    return animateTo(zoom: newZoom, curve: curve, customId: customId);
   }
 
   /// Will use the [centerZoomFitBounds] method with [bounds] and [options] to
@@ -212,6 +295,7 @@ class AnimatedMapController extends MapControllerImpl {
     LatLngBounds bounds, {
     FitBoundsOptions? options,
     Curve? curve,
+    String? customId,
   }) {
     final localOptions =
         options ?? const FitBoundsOptions(padding: EdgeInsets.all(12));
@@ -221,6 +305,7 @@ class AnimatedMapController extends MapControllerImpl {
       dest: centerZoom.center,
       zoom: centerZoom.zoom,
       curve: curve,
+      customId: customId,
     );
   }
 
@@ -235,9 +320,15 @@ class AnimatedMapController extends MapControllerImpl {
     List<LatLng> points, {
     FitBoundsOptions? options,
     Curve? curve,
+    String? customId,
   }) {
     final bounds = LatLngBounds.fromPoints(points);
 
-    return animatedFitBounds(bounds, options: options, curve: curve);
+    return animatedFitBounds(
+      bounds,
+      options: options,
+      curve: curve,
+      customId: customId,
+    );
   }
 }

--- a/lib/src/animated_map_controller.dart
+++ b/lib/src/animated_map_controller.dart
@@ -7,6 +7,14 @@ import 'package:flutter_map_animations/src/animation_id.dart';
 import 'package:flutter_map_animations/src/lat_lng_tween.dart';
 import 'package:latlong2/latlong.dart';
 
+typedef _MovementCallback = bool Function(
+  CurvedAnimation animation,
+  LatLngTween latLngTween,
+  Tween<double> zoomTween,
+  Tween<double> rotateTween,
+  AnimationId animationId,
+);
+
 /// A [MapController] that provides animated methods.
 class AnimatedMapController extends MapControllerImpl {
   /// Creates a [MapController] that provides animated methods.
@@ -170,13 +178,7 @@ class AnimatedMapController extends MapControllerImpl {
   // Determine what MapController method should be called based on whether
   // there is movement and/or rotation. If there is neither movement nor
   // rotation null is returned.
-  bool Function(
-    CurvedAnimation animation,
-    LatLngTween latLngTween,
-    Tween<double> zoomTween,
-    Tween<double> rotateTween,
-    AnimationId animationId,
-  )? _movementCallback({
+  _MovementCallback? _movementCallback({
     required bool hasMovement,
     required bool hasRotation,
   }) {

--- a/lib/src/animation_id.dart
+++ b/lib/src/animation_id.dart
@@ -43,8 +43,7 @@ class AnimationId {
     try {
       final animationId = AnimationId.parse(id);
       return animationId;
-    } catch (e, s) {
-      debugPrintStack(label: e.toString(), stackTrace: s);
+    } catch (e) {
       return null;
     }
   }

--- a/test/src/animation_id_test.dart
+++ b/test/src/animation_id_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_map/plugin_api.dart';
 import 'package:flutter_map_animations/src/animation_id.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
@@ -5,6 +6,7 @@ import 'package:latlong2/latlong.dart';
 void main() {
   group('AnimationId', () {
     const validId = 'started#51.0,0.0,1.0';
+    const validIdWithCustomId = 'started#51.0,0.0,1.0#aCustomId';
     const invalidId = 'invalid#51.0,0.0,1.0';
 
     group('id', () {
@@ -25,6 +27,19 @@ void main() {
         expect(animationId, isA<AnimationId>());
       });
 
+      test('should return a customId', () {
+        final animationId = AnimationId.parse(validIdWithCustomId);
+
+        expect(
+          animationId,
+          isA<AnimationId>().having(
+            (animationId) => animationId.customId,
+            'customId',
+            'aCustomId',
+          ),
+        );
+      });
+
       test('should throw an error if the moveId is invalid', () {
         expect(() => AnimationId.parse(invalidId), throwsArgumentError);
       });
@@ -39,6 +54,36 @@ void main() {
 
       test('should return null if the moveId is invalid', () {
         final animationId = AnimationId.tryParse(invalidId);
+
+        expect(animationId, isNull);
+      });
+    });
+
+    group('fromMapEvent', () {
+      test('should return an AnimationId', () {
+        final animationId = AnimationId.fromMapEvent(
+          MapEventMove(
+            center: LatLng(1, 2),
+            zoom: 6,
+            targetCenter: LatLng(2, 4),
+            targetZoom: 5,
+            source: MapEventSource.custom,
+            id: validId,
+          ),
+        );
+
+        expect(animationId, isNotNull);
+      });
+
+      test('should return null if the MapEvent is not a MapEventMove', () {
+        final animationId = AnimationId.fromMapEvent(
+          MapEventTap(
+            center: LatLng(1, 2),
+            zoom: 6,
+            source: MapEventSource.custom,
+            tapPosition: LatLng(3, 4),
+          ),
+        );
 
         expect(animationId, isNull);
       });


### PR DESCRIPTION
Adding an optional customId allows users to change the TileLayer's tileUpdateTransformer behaviour based on what triggers an animated movement.

In passing I noticed that it was possible to optimise the movement such that no calls to the MapController are made if no movement occurs and if both movement/rotation occur the MapControllers moveAndRotate method is used which is more efficient than calling both move() and rotate().

I also added a check to make sure that if we animate movement that we don't repeat the last movement (when animation.value == 1.0) and that we use the AnimatedMoveId.finish id exactly once.

---

Note in working on this I noticed a bug in my work for flutter_map 4.0.0 that actually breaks tileUpdateTransformers. The fix is merged in to master (https://github.com/fleaflet/flutter_map/pull/1534) which will be released in 4.0.0. If it's helpful I have a branch on my own fork to apply it to 4.0.0: https://github.com/rorystephenson/flutter_map/tree/map-id-fix

---

Don't hesitate to modify/remove my changes if you don't like them. The reduced calls to MapController is actually technically a breaking change.