### PR TITLE
Preparing for flutter_map v6

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -52,7 +52,7 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
           return FlutterMap(
             mapController: _animatedMapController.mapController,
             options: MapOptions(
-              center: center,
+              initialCenter: center,
               onTap: (_, point) => _addMarker(point),
             ),
             children: [
@@ -119,8 +119,11 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
               if (markers.value.isEmpty) return;
 
               final points = markers.value.map((m) => m.point).toList();
-              _animatedMapController.centerOnPoints(
-                points,
+              _animatedMapController.animatedFitCamera(
+                cameraFit: CameraFit.coordinates(
+                  coordinates: points,
+                  padding: const EdgeInsets.all(12),
+                ),
                 customId: _useTransformer ? _useTransformerId : null,
               );
             },
@@ -160,7 +163,6 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
           point: point,
           width: markerSize,
           height: markerSize,
-          anchorPos: AnchorPos.align(AnchorAlign.top),
           builder: (context, animation) {
             final size = markerSize * animation.value;
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -73,10 +73,11 @@ packages:
   flutter_map:
     dependency: "direct main"
     description:
-      name: flutter_map
-      sha256: "5286f72f87deb132daa1489442d6cc46e986fc105cb727d9ae1b602b35b1d1f3"
-      url: "https://pub.dev"
-    source: hosted
+      path: "."
+      ref: flutter-map-state-refactor
+      resolved-ref: f5d6d136882e35187817de90ee95b4318eefe9da
+      url: "https://github.com/rorystephenson/flutter_map"
+    source: git
     version: "5.0.0"
   flutter_map_animations:
     dependency: "direct main"
@@ -289,4 +290,3 @@ packages:
     version: "2.0.0"
 sdks:
   dart: ">=3.0.0 <4.0.0"
-  flutter: ">=3.10.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -66,19 +66,18 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      sha256: "2118df84ef0c3ca93f96123a616ae8540879991b8b57af2f81b76a7ada49b2a4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   flutter_map:
     dependency: "direct main"
     description:
-      path: "."
-      ref: flutter-map-state-refactor
-      resolved-ref: f5d6d136882e35187817de90ee95b4318eefe9da
-      url: "https://github.com/rorystephenson/flutter_map"
-    source: git
-    version: "5.0.0"
+      name: flutter_map
+      sha256: "9243fcc8d0b544720af6fd3b827428f6a362364445b9c16f83a73a85ce939f90"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0-dev.1"
   flutter_map_animations:
     dependency: "direct main"
     description:
@@ -290,3 +289,4 @@ packages:
     version: "2.0.0"
 sdks:
   dart: ">=3.0.0 <4.0.0"
+  flutter: ">=3.10.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -77,3 +77,9 @@ flutter:
   #
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/custom-fonts/#from-packages
+
+dependency_overrides:
+  flutter_map:
+    git:
+      url: https://github.com/rorystephenson/flutter_map
+      ref: flutter-map-state-refactor

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -29,16 +29,16 @@ environment:
 # the latest version available on pub.dev. To see which dependencies have newer
 # versions available, run `flutter pub outdated`.
 dependencies:
-  cupertino_icons: ^1.0.2
+  cupertino_icons: ^1.0.5
   flutter:
     sdk: flutter
-  flutter_map: ^5.0.0
+  flutter_map: ^6.0.0-dev.1
   flutter_map_animations:
     path: ../
   latlong2: ^0.9.0
 
 dev_dependencies:
-  flutter_lints: ^2.0.0
+  flutter_lints: ^2.0.2
   flutter_test:
     sdk: flutter
 
@@ -77,9 +77,3 @@ flutter:
   #
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/custom-fonts/#from-packages
-
-dependency_overrides:
-  flutter_map:
-    git:
-      url: https://github.com/rorystephenson/flutter_map
-      ref: flutter-map-state-refactor

--- a/lib/src/animated_map_controller.dart
+++ b/lib/src/animated_map_controller.dart
@@ -100,8 +100,9 @@ class AnimatedMapController {
       );
     }
 
-    final effectiveDest = dest ?? mapController.camera.center;
-    final effectiveZoom = zoom ?? mapController.camera.zoom;
+    final camera = mapController.camera;
+    final effectiveDest = dest ?? camera.center;
+    final effectiveZoom = zoom ?? camera.zoom;
     final effectiveRotation = rotation ?? this.rotation;
     final latLngTween = LatLngTween(
       begin: mapController.camera.center,

--- a/lib/src/animated_marker_layer.dart
+++ b/lib/src/animated_marker_layer.dart
@@ -44,15 +44,15 @@ class AnimatedMarkerLayer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final map = FlutterMapState.maybeOf(context);
-    if (map == null) {
+    final mapCamera = MapCamera.maybeOf(context);
+    if (mapCamera == null) {
       throw StateError('No FlutterMapState found.');
     }
 
     final markerWidgets = <Widget>[];
 
     for (final marker in markers) {
-      final pxPoint = map.project(marker.point);
+      final pxPoint = mapCamera.project(marker.point);
 
       // See if any portion of the Marker rect resides in the map bounds
       // If not, don't spend any resources on build function.
@@ -60,7 +60,7 @@ class AnimatedMarkerLayer extends StatelessWidget {
       // Note that Anchor coordinates of (0,0) are at bottom-right of the Marker
       // unlike the map coordinates.
       final anchor = Anchor.fromPos(
-        marker.anchorPos ?? anchorPos ?? AnchorPos.align(AnchorAlign.center),
+        marker.anchorPos ?? anchorPos ?? AnchorPos.defaultAnchorPos,
         marker.width,
         marker.height,
       );
@@ -76,14 +76,14 @@ class AnimatedMarkerLayer extends StatelessWidget {
       );
       final ne = CustomPoint(pxPoint.x - rightPortion, pxPoint.y + topPortion);
 
-      if (!map.pixelBounds.containsPartialBounds(Bounds(sw, ne))) {
+      if (!mapCamera.pixelBounds.containsPartialBounds(Bounds(sw, ne))) {
         continue;
       }
 
-      final pos = pxPoint - map.pixelOrigin;
+      final pos = pxPoint - mapCamera.pixelOrigin;
       final markerWidget = (marker.rotate ?? rotate)
           ? Transform.rotate(
-              angle: -map.rotationRad,
+              angle: -mapCamera.rotationRad,
               origin: marker.rotateOrigin ?? rotateOrigin,
               alignment: marker.rotateAlignment ?? rotateAlignment,
               child: _AnimatedMarkerWidget(marker: marker),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,16 +15,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_map: ^5.0.0
+  flutter_map: ^6.0.0-dev.1
   latlong2: ^0.9.0
 
 dev_dependencies:
   fd_lints: ^2.0.1
   flutter_test:
     sdk: flutter
-
-dependency_overrides:
-  flutter_map:
-    git:
-      url: https://github.com/rorystephenson/flutter_map
-      ref: flutter-map-state-refactor

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,3 +22,9 @@ dev_dependencies:
   fd_lints: ^2.0.1
   flutter_test:
     sdk: flutter
+
+dependency_overrides:
+  flutter_map:
+    git:
+      url: https://github.com/rorystephenson/flutter_map
+      ref: flutter-map-state-refactor

--- a/test/src/animation_id_test.dart
+++ b/test/src/animation_id_test.dart
@@ -62,11 +62,21 @@ void main() {
     group('fromMapEvent', () {
       test('should return an AnimationId', () {
         final animationId = AnimationId.fromMapEvent(
-          const MapEventMove(
-            center: LatLng(1, 2),
-            zoom: 6,
-            targetCenter: LatLng(2, 4),
-            targetZoom: 5,
+          MapEventMove(
+            oldCamera: MapCamera(
+              center: const LatLng(1, 2),
+              zoom: 6,
+              crs: CrsSimple(),
+              rotation: 0,
+              nonRotatedSize: const CustomPoint(50, 100),
+            ),
+            camera: MapCamera(
+              center: const LatLng(2, 4),
+              zoom: 5,
+              crs: CrsSimple(),
+              rotation: 0,
+              nonRotatedSize: const CustomPoint(50, 100),
+            ),
             source: MapEventSource.custom,
             id: validId,
           ),
@@ -77,11 +87,16 @@ void main() {
 
       test('should return null if the MapEvent is not a MapEventMove', () {
         final animationId = AnimationId.fromMapEvent(
-          const MapEventTap(
-            center: LatLng(1, 2),
-            zoom: 6,
+          MapEventTap(
+            camera: MapCamera(
+              center: const LatLng(1, 2),
+              zoom: 6,
+              crs: CrsSimple(),
+              rotation: 0,
+              nonRotatedSize: const CustomPoint(50, 100),
+            ),
             source: MapEventSource.custom,
-            tapPosition: LatLng(3, 4),
+            tapPosition: const LatLng(3, 4),
           ),
         );
 


### PR DESCRIPTION
@TesteurManiak I'm trying my own packages against the proposed flutter_map refactor branch and since some of my packages use this one in the examples I have started migrating it as well. I'm not sure how you want to handle deprecations and whether you want to deprecate the `centerOnPoints` method or not, in any case I figured I'd open this PR in case the changes can be useful when v6 is eventually released.