### PR TITLE
fix: update camera with correct rotation

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -126,6 +126,7 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
                   coordinates: points,
                   padding: const EdgeInsets.all(12),
                 ),
+                rotation: 0,
                 customId: _useTransformer ? _useTransformerId : null,
               );
             },

--- a/lib/src/animated_map_controller.dart
+++ b/lib/src/animated_map_controller.dart
@@ -344,7 +344,12 @@ class AnimatedMapController {
     String? customId,
     double? rotation,
   }) {
-    final centerZoom = cameraFit.fit(mapController.camera);
+    MapCamera camera = mapController.camera;
+    if (rotation != null) {
+      camera = camera.withRotation(rotation);
+    }
+
+    final centerZoom = cameraFit.fit(camera);
 
     return animateTo(
       dest: centerZoom.center,


### PR DESCRIPTION
Recalculate the new `MapCamera` according to the `rotation` parameter.

Fix #15 