### PR TITLE
Added `offset` support to `animateTo`

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -34,6 +34,7 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
   final center = const LatLng(51.509364, -0.128928);
 
   bool _useTransformer = true;
+  int _lastMovedToMarkerIndex = -1;
 
   late final _animatedMapController = AnimatedMapController(vsync: this);
 
@@ -131,6 +132,49 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
               );
             },
             child: const Icon(Icons.center_focus_strong),
+          ),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              FloatingActionButton(
+                tooltip: 'Move to next marker with offset',
+                onPressed: () {
+                  if (markers.value.isEmpty) return;
+
+                  final points = markers.value.map((m) => m.point);
+                  setState(
+                    () => _lastMovedToMarkerIndex =
+                        (_lastMovedToMarkerIndex + 1) % points.length,
+                  );
+
+                  _animatedMapController.animateTo(
+                    dest: points.elementAt(_lastMovedToMarkerIndex),
+                    customId: _useTransformer ? _useTransformerId : null,
+                    offset: const Offset(100, 100),
+                  );
+                },
+                child: const Icon(Icons.multiple_stop),
+              ),
+              const SizedBox.square(dimension: 8),
+              FloatingActionButton(
+                tooltip: 'Move to next marker',
+                onPressed: () {
+                  if (markers.value.isEmpty) return;
+
+                  final points = markers.value.map((m) => m.point);
+                  setState(
+                    () => _lastMovedToMarkerIndex =
+                        (_lastMovedToMarkerIndex + 1) % points.length,
+                  );
+
+                  _animatedMapController.animateTo(
+                    dest: points.elementAt(_lastMovedToMarkerIndex),
+                    customId: _useTransformer ? _useTransformerId : null,
+                  );
+                },
+                child: const Icon(Icons.polyline_rounded),
+              ),
+            ],
           ),
           FloatingActionButton.extended(
             label: Row(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.5.0"
+    version: "0.5.2"
   flutter_map_cancellable_tile_provider:
     dependency: "direct main"
     description:

--- a/lib/src/animated_map_controller.dart
+++ b/lib/src/animated_map_controller.dart
@@ -11,6 +11,7 @@ typedef _MovementCallback = bool Function(
   CurvedAnimation animation,
   LatLngTween latLngTween,
   Tween<double> zoomTween,
+  Offset offset,
   Tween<double> rotateTween,
   AnimationId animationId,
 );
@@ -79,6 +80,9 @@ class AnimatedMapController {
   /// Animate the map to [dest] with an optional [zoom] level and [rotation] in
   /// degrees.
   ///
+  /// [offset] is only supported where [rotation] is `null`, due to a flutter_map
+  /// limitation.
+  ///
   /// If specified, [zoom] must be greater or equal to 0.
   ///
   /// {@template animated_map_controller.animate_to.curve}
@@ -88,6 +92,7 @@ class AnimatedMapController {
   Future<void> animateTo({
     LatLng? dest,
     double? zoom,
+    Offset offset = Offset.zero,
     double? rotation,
     Curve? curve,
     String? customId,
@@ -184,6 +189,7 @@ class AnimatedMapController {
         animation,
         latLngTween,
         zoomTween,
+        offset,
         rotateTween,
         animationId,
       );
@@ -200,7 +206,14 @@ class AnimatedMapController {
     required bool hasRotation,
   }) {
     if (hasMovement && hasRotation) {
-      return (animation, latLngTween, zoomTween, rotateTween, animationId) {
+      return (
+        animation,
+        latLngTween,
+        zoomTween,
+        offset,
+        rotateTween,
+        animationId,
+      ) {
         final result = mapController.moveAndRotate(
           latLngTween.evaluate(animation),
           zoomTween.evaluate(animation),
@@ -210,14 +223,29 @@ class AnimatedMapController {
         return result.moveSuccess || result.rotateSuccess;
       };
     } else if (hasMovement) {
-      return (animation, latLngTween, zoomTween, rotateTween, animationId) =>
+      return (
+        animation,
+        latLngTween,
+        zoomTween,
+        offset,
+        rotateTween,
+        animationId,
+      ) =>
           mapController.move(
             latLngTween.evaluate(animation),
             zoomTween.evaluate(animation),
+            offset: offset,
             id: animationId.id,
           );
     } else if (hasRotation) {
-      return (animation, latLngTween, zoomTween, rotateTween, animationId) =>
+      return (
+        animation,
+        latLngTween,
+        zoomTween,
+        offset,
+        rotateTween,
+        animationId,
+      ) =>
           mapController.rotate(
             rotateTween.evaluate(animation),
             id: animationId.id,

--- a/lib/src/animated_map_controller.dart
+++ b/lib/src/animated_map_controller.dart
@@ -11,7 +11,7 @@ typedef _MovementCallback = bool Function(
   CurvedAnimation animation,
   LatLngTween latLngTween,
   Tween<double> zoomTween,
-  Offset offset,
+  Tween<Offset> offset,
   Tween<double> rotateTween,
   AnimationId animationId,
 );
@@ -117,6 +117,10 @@ class AnimatedMapController {
       begin: mapController.camera.zoom,
       end: effectiveZoom,
     );
+    final offsetTween = Tween<Offset>(
+      begin: Offset.zero,
+      end: offset,
+    );
     double startRotation = this.rotation;
     double endRotation = effectiveRotation;
 
@@ -189,7 +193,7 @@ class AnimatedMapController {
         animation,
         latLngTween,
         zoomTween,
-        offset,
+        offsetTween,
         rotateTween,
         animationId,
       );
@@ -210,7 +214,7 @@ class AnimatedMapController {
         animation,
         latLngTween,
         zoomTween,
-        offset,
+        offsetTween,
         rotateTween,
         animationId,
       ) {
@@ -227,14 +231,14 @@ class AnimatedMapController {
         animation,
         latLngTween,
         zoomTween,
-        offset,
+        offsetTween,
         rotateTween,
         animationId,
       ) =>
           mapController.move(
             latLngTween.evaluate(animation),
             zoomTween.evaluate(animation),
-            offset: offset,
+            offset: offsetTween.evaluate(animation),
             id: animationId.id,
           );
     } else if (hasRotation) {
@@ -242,7 +246,7 @@ class AnimatedMapController {
         animation,
         latLngTween,
         zoomTween,
-        offset,
+        offsetTween,
         rotateTween,
         animationId,
       ) =>


### PR DESCRIPTION
Fixes #19.

Also adds new functionality to the example app, useful for testing.

Due to a flutter_map limitation (honestly, who even maintains that package :D), `offset` is only supported where `rotate` is `null`.