### PR TITLE
fix: added dedicated `_AngleTween` to improve rotation animation

### DIFF
--- a/lib/src/animated_map_controller.dart
+++ b/lib/src/animated_map_controller.dart
@@ -380,33 +380,6 @@ class AnimatedMapController {
       rotation: rotation,
     );
   }
-
-  /// Will use the [LatLngBounds.fromPoints] method to calculate the bounds of
-  /// the [points] and then use the [animatedFitCamera] method to animate to
-  /// that position.
-  ///
-  /// {@macro animated_map_controller.animate_to.curve}
-  @Deprecated(
-    'Prefer `animatedFitCamera` with a `CameraFit.coordiantes() or CameraFit.bounds()` instead. '
-    'This method will be removed in a future release as it is now redundant. '
-    'This method is deprecated since v0.5.0',
-  )
-  Future<void> centerOnPoints(
-    List<LatLng> points, {
-    Curve? curve,
-    String? customId,
-  }) {
-    final cameraFit = CameraFit.bounds(
-      bounds: LatLngBounds.fromPoints(points),
-      padding: const EdgeInsets.all(12),
-    );
-
-    return animatedFitCamera(
-      cameraFit: cameraFit,
-      curve: curve,
-      customId: customId,
-    );
-  }
 }
 
 class _AngleTween extends Tween<double> {

--- a/lib/src/animated_map_controller.dart
+++ b/lib/src/animated_map_controller.dart
@@ -123,7 +123,7 @@ class AnimatedMapController {
     double startRotation = this.rotation;
     double endRotation = effectiveRotation;
 
-    final rotateTween = AngleTween(
+    final rotateTween = _AngleTween(
       begin: startRotation,
       end: endRotation,
     );

--- a/lib/src/animated_map_controller.dart
+++ b/lib/src/animated_map_controller.dart
@@ -123,7 +123,7 @@ class AnimatedMapController {
     double startRotation = this.rotation;
     double endRotation = effectiveRotation;
 
-    final rotateTween = _AngleTween(
+    final rotateTween = AngleTween(
       begin: startRotation,
       end: endRotation,
     );
@@ -329,32 +329,6 @@ class AnimatedMapController {
     return animateTo(zoom: newZoom, curve: curve, customId: customId);
   }
 
-  @Deprecated(
-    'Prefer `animatedFitCamera` with a `CameraFit.bounds()` instead. '
-    'This method will be removed in a future release as it is now redundant. '
-    'This method is deprecated since v0.5.0',
-  )
-  Future<void> animatedFitBounds(
-    LatLngBounds bounds, {
-    FitBoundsOptions? options,
-    Curve? curve,
-    String? customId,
-  }) {
-    final cameraFit = options == null
-        ? CameraFit.bounds(bounds: bounds)
-        : CameraFit.bounds(
-            bounds: bounds,
-            padding: options.padding,
-            maxZoom: options.maxZoom,
-            forceIntegerZoomLevel: options.forceIntegerZoomLevel,
-          );
-    return animatedFitCamera(
-      cameraFit: cameraFit,
-      curve: curve,
-      customId: customId,
-    );
-  }
-
   /// Will use the [cameraFit] to calculate the center and zoom level and then
   /// animate to that position.
   ///
@@ -378,6 +352,33 @@ class AnimatedMapController {
       curve: curve,
       customId: customId,
       rotation: rotation,
+    );
+  }
+
+  /// Will use the [LatLngBounds.fromPoints] method to calculate the bounds of
+  /// the [points] and then use the [animatedFitCamera] method to animate to
+  /// that position.
+  ///
+  /// {@macro animated_map_controller.animate_to.curve}
+  @Deprecated(
+    'Prefer `animatedFitCamera` with a `CameraFit.coordiantes() or CameraFit.bounds()` instead. '
+    'This method will be removed in a future release as it is now redundant. '
+    'This method is deprecated since v0.5.0',
+  )
+  Future<void> centerOnPoints(
+    List<LatLng> points, {
+    Curve? curve,
+    String? customId,
+  }) {
+    final cameraFit = CameraFit.bounds(
+      bounds: LatLngBounds.fromPoints(points),
+      padding: const EdgeInsets.all(12),
+    );
+
+    return animatedFitCamera(
+      cameraFit: cameraFit,
+      curve: curve,
+      customId: customId,
     );
   }
 }

--- a/lib/src/animated_map_controller.dart
+++ b/lib/src/animated_map_controller.dart
@@ -123,17 +123,7 @@ class AnimatedMapController {
     double startRotation = this.rotation;
     double endRotation = effectiveRotation;
 
-    // If the difference between the bearings is greater than 180 degrees,
-    // add or subtract 360 degrees to one of them to make the shortest
-    // rotation direction counterclockwise.
-    final diff = endRotation - startRotation;
-    if (diff > 180.0) {
-      startRotation += 360.0;
-    } else if (diff < -180.0) {
-      endRotation += 360.0;
-    }
-
-    final rotateTween = Tween<double>(
+    final rotateTween = _AngleTween(
       begin: startRotation,
       end: endRotation,
     );
@@ -339,6 +329,32 @@ class AnimatedMapController {
     return animateTo(zoom: newZoom, curve: curve, customId: customId);
   }
 
+  @Deprecated(
+    'Prefer `animatedFitCamera` with a `CameraFit.bounds()` instead. '
+    'This method will be removed in a future release as it is now redundant. '
+    'This method is deprecated since v0.5.0',
+  )
+  Future<void> animatedFitBounds(
+    LatLngBounds bounds, {
+    FitBoundsOptions? options,
+    Curve? curve,
+    String? customId,
+  }) {
+    final cameraFit = options == null
+        ? CameraFit.bounds(bounds: bounds)
+        : CameraFit.bounds(
+            bounds: bounds,
+            padding: options.padding,
+            maxZoom: options.maxZoom,
+            forceIntegerZoomLevel: options.forceIntegerZoomLevel,
+          );
+    return animatedFitCamera(
+      cameraFit: cameraFit,
+      curve: curve,
+      customId: customId,
+    );
+  }
+
   /// Will use the [cameraFit] to calculate the center and zoom level and then
   /// animate to that position.
   ///
@@ -390,5 +406,17 @@ class AnimatedMapController {
       curve: curve,
       customId: customId,
     );
+  }
+}
+
+class _AngleTween extends Tween<double> {
+  _AngleTween({required double super.begin, required double super.end});
+
+  @override
+  double lerp(double t) => begin! + _angleDifference(begin!, end!) * t;
+
+  static double _angleDifference(double angle1, double angle2) {
+    final diff = (angle2 - angle1 + 180) % 360 - 180;
+    return diff < -180 ? diff + 360 : diff;
   }
 }


### PR DESCRIPTION

Current animated rotation behaviour:

https://github.com/TesteurManiak/flutter_map_animations/assets/58115698/e5a7f9be-74f8-4a68-9e7e-1c934cc1c26f

New animated rotation behaviour:

https://github.com/TesteurManiak/flutter_map_animations/assets/58115698/485704f4-39c3-4a75-9c94-e783c2e0b39d


I haven't fully tested these changes. They just introduce a dedicated tween to better animate between the shortest angle diff.
