### PR TITLE
[FIX] Animation on same point w/ offset

### DIFF
--- a/lib/src/animated_map_controller.dart
+++ b/lib/src/animated_map_controller.dart
@@ -134,7 +134,8 @@ class AnimatedMapController {
     final bool hasRotation = rotation != null && rotation != this.rotation;
     final bool hasMovement =
         (dest != null && dest != mapController.camera.center) ||
-            (zoom != null && zoom != mapController.camera.zoom);
+            (zoom != null && zoom != mapController.camera.zoom) ||
+            (offset != null);
     final movementCallback =
         _movementCallback(hasMovement: hasMovement, hasRotation: hasRotation);
     if (movementCallback == null) return Future.value();


### PR DESCRIPTION
**Problem:** I was trying to animate to the same point with different offsets when showing/closing a bottom sheet. This did not work due to the movementCallback being set to null after hitting this line that prevents duplicate destinations from being animated to:

`final bool hasMovement =
        (dest != null && dest != mapController.camera.center) ||
            (zoom != null && zoom != mapController.camera.zoom);`

**Solution:** Added a null check to the offset value when assigning movementCallback.