### PR TITLE
a method to stop and dispose previous animations.

### DIFF
--- a/lib/src/animated_map_controller.dart
+++ b/lib/src/animated_map_controller.dart
@@ -63,13 +63,16 @@ class AnimatedMapController {
   /// Controller of the current animation.
   AnimationController? _animationController;
 
-  void dispose() {
+  void stopAndDisposeAnimationController() {
     final isAnimating = _animationController?.isAnimating ?? false;
     if (isAnimating) {
       _animationController?.stop();
     }
     _animationController?.dispose();
+  }
 
+  void dispose() {
+    stopAndDisposeAnimationController();
     // Dispose the map controller if it was created internally.
     if (_internal) {
       mapController.dispose();
@@ -145,6 +148,7 @@ class AnimatedMapController {
       vsync: vsync,
       duration: duration ?? this.duration,
     );
+    stopAndDisposeAnimationController();
     _animationController = animationController;
 
     final animation = CurvedAnimation(


### PR DESCRIPTION
I noticed that disposing of the FlutterMap immediately after I had triggered several animateTo calls caused an error because the tickers of those animationControllers were still running.

This change performs the code that was in the dispose() method in the animateTo() method as well as dispose().