### PR TITLE
Fix: Stop and dispose all running animations

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -92,7 +92,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.7.1"
   flutter_map_cancellable_tile_provider:
     dependency: "direct main"
     description:
@@ -142,18 +142,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -198,18 +198,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -291,10 +291,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -323,10 +323,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
   web:
     dependency: transitive
     description:

--- a/lib/src/animated_map_controller.dart
+++ b/lib/src/animated_map_controller.dart
@@ -60,15 +60,15 @@ class AnimatedMapController {
     return effectiveRotation;
   }
 
-  /// Controller of the current animation.
-  AnimationController? _animationController;
+  final _runningAnimations = <AnimationController>{};
 
   void dispose() {
-    final isAnimating = _animationController?.isAnimating ?? false;
-    if (isAnimating) {
-      _animationController?.stop();
+    // Stop running animations and dispose their controllers.
+    for (final animation in _runningAnimations) {
+      final isAnimating = animation.isAnimating;
+      if (isAnimating) animation.stop();
+      animation.dispose();
     }
-    _animationController?.dispose();
 
     // Dispose the map controller if it was created internally.
     if (_internal) {
@@ -145,14 +145,14 @@ class AnimatedMapController {
       vsync: vsync,
       duration: duration ?? this.duration,
     );
-    _animationController = animationController;
+    _runningAnimations.add(animationController);
 
     final animation = CurvedAnimation(
       parent: animationController,
       curve: curve ?? this.curve,
     )..onEnd(() {
         animationController.dispose();
-        _animationController = null;
+        _runningAnimations.remove(animationController);
       });
 
     AnimationId animationId = AnimationId(


### PR DESCRIPTION
Fix #43 

Similar to #44 but doesn't change the behaviour of cancelling an ongoing animation. Deciding to cancel a running animation when a new one is triggered should be discussed separately, as some users might want to chain animations instead of cancelling it.

EDIT: Added a public method `stopAnimations()` on the controller to cancel all ongoing animations and a property `cancelPreviousAnimations` which when set to `true` will perform a call to `stopAnimations()` before triggering a new animations.