### PR TITLE
Defer AnimationController.forward() to post-frame in AnimatedMapController.animateTo

### DIFF
--- a/lib/src/animated_map_controller.dart
+++ b/lib/src/animated_map_controller.dart
@@ -212,7 +212,13 @@ class AnimatedMapController {
       );
     });
 
-    return animationController.forward();
+    // Defer the animation start until after the current frame to ensure
+    // the underlying MapInteractiveViewer has completed initialization.
+    final completer = Completer<void>();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      animationController.forward().then(completer.complete);
+    });
+    return completer.future;
   }
 
   // Determine what MapController method should be called based on whether


### PR DESCRIPTION
Fixes a first-animation race where MapInteractiveViewer hasn’t finished wiring (_interactiveViewerState not yet attached), causing LateInitializationError.
  
- Root cause: animateTo() starts the animation during the same build/frame as FlutterMap initialization. The first animation tick calls mapController.move() before the viewer is ready.
  
- Change: defer animation start using WidgetsBinding.instance.addPostFrameCallback before AnimationController.forward().

- Backwards compatible: same behavior, first animation delayed by ≤1 frame; no API changes.
  
  
- Related but not required: a complementary fix in flutter_map defers re-entrant viewer updates during build. This PR stands alone and still prevents the LateInitializationError on its own.

